### PR TITLE
issue#426 - Обновление карточек на welcome без перезагрузки страницы

### DIFF
--- a/public/views/main/welcome.html
+++ b/public/views/main/welcome.html
@@ -114,6 +114,7 @@
 	<div class="toolbar-min">
 		<img class="logo"
 			 ui-sref="welcome"
+			 ui-sref-opts="{reload: true}"
 			 src="images/logo.png"/>
 		<div class="welcome-email">{{userInfo.name}}</div>
 		<div class="welcome-logout" ng-click="logout()">


### PR DESCRIPTION
Влад, помнишь мы с тобой обсуждали момент, когда после прохождения урока, карточки на welcome не перезагружались. Скорее всего, мы с тобой подразумевали ситуацию, когда мы находились на welcome и пытались обновить состояние текущей страницы кликом на надпись 'spacecraft' верхней панели, а с другой вкладки, к примеру, проходили сам урок.

_Теперь, ближе к пояснению причины проблемы:_
Когда ты с какого-то другого state'a идешь на welcome - проблем нет, потому как сервис state понимает, что текущий location отличается от того, на который собираемся переходить,
и он начинает переинициализировать все resolve'ы соответствующие state'у, на который переходим.

А вот ситуация, когда ты находишься на текущем state'е и на него же пытаешься перейти - не инициирует перегрузку resolve'ов (что нас и интересует). Из доков (https://github.com/angular-ui/ui-router/wiki/Quick-Reference#options):

> reload v0.2.5 Boolean (default false), If true will force transition even if the state or params have not changed, aka a reload of the same state. It differs from reloadOnSearch because you'd use this when you want to force a reload when everything is the same, including search params.


 Поэтому, находясь на welcome и кликнув на надпись 'spacecraft' на верхней панели, карточки не будут перезагружаться. Приходилось либо обновлять страницу явно, либо уходить на другой state, а потом обратно на welcome.